### PR TITLE
Fix light theme flash on blog navigation

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -39,3 +39,11 @@
         document.getElementById('theme-toggle')?.addEventListener('click', handleToggleClick);
     });
 </script>
+
+<script>
+    document.addEventListener('astro:after-swap', () => {
+        if (localStorage.theme === 'dark') {
+            document.documentElement.classList.add('dark');
+        }
+    });
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ const { showHeader = true, ...head } = Astro.props;
 <html lang="en" class="antialiased break-words">
     <head>
         <BaseHead {...head} />
-        <script is:inline>
+        <script>
             if (localStorage.theme === 'dark') {
                 document.documentElement.classList.add('dark');
             }


### PR DESCRIPTION
The PR adds a script inside `ThemeToggle.astro` which runs on the `astro:after-swap-event`, which means before the swapped page is rendered, and removes the `is:inline` directive from the `BaseLayout` script, so that it only runs on the first render. This approach is suggested [here](https://docs.astro.build/en/tutorials/add-view-transitions/#update-scripts). It avoids flashes in the theme, which quickly turned to light and then back to dark when navigating to a blog post page.

Closes #3.