### PR TITLE
Fix Chinese character support in tags page

### DIFF
--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -8,7 +8,7 @@ export function slugify(input?: string) {
     slug = slug.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
     // replace invalid chars with spaces
-    slug = slug.replace(/[^a-z0-9\s-]/g, ' ').trim();
+    // slug = slug.replace(/[^a-z0-9\s-]/g, ' ').trim();
 
     // replace multiple spaces or hyphens with a single hyphen
     slug = slug.replace(/[\s-]+/g, '-');


### PR DESCRIPTION
When using Chinese characters in tags, the tags page encounters errors upon opening in the browser. After inspecting the source code, it was found that a particular line causes the issue. By commenting out this line, the page functions normally.