### PR TITLE
Fix background color flicker in dark mode

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,7 +14,7 @@ const { showHeader = true, ...head } = Astro.props;
 <html lang="en" class="antialiased break-words">
     <head>
         <BaseHead {...head} />
-        <script>
+        <script is:inline>
             if (localStorage.theme === 'dark') {
                 document.documentElement.classList.add('dark');
             }


### PR DESCRIPTION
Issue:
When in dark mode, refreshing a page results in the background to switch back to white for a split second.

Fix:
This change results in the already existing script that sets the theme to run immediately, before the page content loads.
It fixes it for me, but I would appreciate if someone else checked as well (I'm using chrome on macos).
See: https://docs.astro.build/en/reference/directives-reference/#isinline

Note:
This issue (and even a fix :)) was mentioned in the past here:
https://github.com/JustGoodUI/dante-astro-theme/pull/4#issuecomment-1904908107